### PR TITLE
feat(android): backgroundColor property in imageAsResized

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Creates a new image by creating a copy of the given image that is rescaled to th
         * imagefactory.QUALITY\_MEDIUM
         * imagefactory.QUALITY\_HIGH
     * Android. format [int]: The output format of the image: either ImageFactory.PNG or ImageFactory.JPEG (default: ImageFactory.JPEG)
-    * Android. backgroundColor [int]: Background color of the resized image e.g. when using a transparent PNG (default: Black)
+    * Android. backgroundColor [int]: Background color of the resized image e.g. when using a transparent PNG that you want to convert to a JPEG.
     * quality[float]: The quality of the resulting JPEG or WebP image, expressed as a value from 0.0 to 1.0. The value 0.0 represents the maximum compression (or lowest quality) while the value 1.0 represents the least compression (or best quality). (default: 0.7)
 
 ### imageAsCropped(blob, options)

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Creates a new image by creating a copy of the given image that is rescaled to th
         * imagefactory.QUALITY\_MEDIUM
         * imagefactory.QUALITY\_HIGH
     * Android. format [int]: The output format of the image: either ImageFactory.PNG or ImageFactory.JPEG (default: ImageFactory.JPEG)
+    * Android. backgroundColor [int]: Background color of the resized image e.g. when using a transparent PNG (default: Black)
     * quality[float]: The quality of the resulting JPEG or WebP image, expressed as a value from 0.0 to 1.0. The value 0.0 represents the maximum compression (or lowest quality) while the value 1.0 represents the least compression (or best quality). (default: 0.7)
 
 ### imageAsCropped(blob, options)

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.1.0
+version: 5.1.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: Image Factory

--- a/android/src/ti/imagefactory/ImageFactory.java
+++ b/android/src/ti/imagefactory/ImageFactory.java
@@ -9,6 +9,7 @@ package ti.imagefactory;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Path;
@@ -18,6 +19,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.common.Log;
+import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.util.TiConvert;
 
@@ -33,7 +35,16 @@ public class ImageFactory
 		args = updateFormatOption(args, blob.getMimeType(), false);
 		Bitmap oldBitmap = blob.getImage();
 		Bitmap newBitmap = imageRotate(oldBitmap, args, TiExifOrientation.from(blob));
-		return compressToBlob(newBitmap, args, (newBitmap != oldBitmap));
+
+		if (args.containsKeyAndNotNull("backgroundColor")) {
+			Bitmap mutableBitmap = newBitmap.copy(Bitmap.Config.ARGB_8888, true);
+			Canvas canvas = new Canvas(mutableBitmap);
+			canvas.drawColor(TiConvert.toColor(args.get("backgroundColor"), TiApplication.getAppRootOrCurrentActivity()));
+			canvas.drawBitmap(newBitmap, 0F, 0F, null);
+			return compressToBlob(mutableBitmap, args, (newBitmap != oldBitmap));
+		} else {
+			return compressToBlob(newBitmap, args, (newBitmap != oldBitmap));
+		}
 	}
 
 	public static Bitmap imageRotate(Bitmap bitmap, KrollDict args, TiExifOrientation exifOrientation)
@@ -147,7 +158,17 @@ public class ImageFactory
 		args = updateFormatOption(args, blob.getMimeType(), false);
 		Bitmap oldBitmap = blob.getImage();
 		Bitmap newBitmap = imageResize(oldBitmap, args, TiExifOrientation.from(blob));
-		return compressToBlob(newBitmap, args, (newBitmap != oldBitmap));
+
+		if (args.containsKeyAndNotNull("backgroundColor")) {
+			Bitmap mutableBitmap = newBitmap.copy(Bitmap.Config.ARGB_8888, true);
+			Canvas canvas = new Canvas(mutableBitmap);
+			canvas.drawColor(TiConvert.toColor(args.get("backgroundColor"), TiApplication.getAppRootOrCurrentActivity()));
+			canvas.drawBitmap(newBitmap, 0F, 0F, null);
+			return compressToBlob(mutableBitmap, args, (newBitmap != oldBitmap));
+		} else {
+			return compressToBlob(newBitmap, args, (newBitmap != oldBitmap));
+		}
+
 	}
 
 	public static Bitmap imageResize(Bitmap bitmap, KrollDict args, TiExifOrientation exifOrientation)


### PR DESCRIPTION
In case you want to resize a PNG in order to save it as a JPG file. Currently it will be black when you save it. This allows you to set a custom color as a background:
```
	row.addEventListener('click', () => {
			const options = {
				width: 320,
				height: 320,
				backgroundColor: "red"
			};
			showImageWindowFor(ImageFactory.imageAsResized(sourceBlob, options));
```
(example/app.js)

[ti.imagefactory-android-5.1.1.zip](https://github.com/user-attachments/files/17921977/ti.imagefactory-android-5.1.1.zip)
